### PR TITLE
Make tox.ini ignore import errors in __init__.py

### DIFF
--- a/snakecord/__init__.py
+++ b/snakecord/__init__.py
@@ -1,2 +1,2 @@
-from .manager import *  # noqa: F401, F403
-from .objects import *  # noqa: F401, F403
+from .manager import *
+from .objects import *

--- a/snakecord/objects/__init__.py
+++ b/snakecord/objects/__init__.py
@@ -1,15 +1,15 @@
-from .baseobject import *  # noqa: F401, F403
-from .channelobject import *  # noqa: F401, F403
-from .embedobject import *  # noqa: F401, F403
-from .emojiobject import *  # noqa: F401, F403
-from .guildobject import *  # noqa: F401, F403
-from .integrationobject import *  # noqa: F401, F403
-from .inviteobject import *  # noqa: F401, F403
-from .memberobject import *  # noqa: F401, F403
-from .messageobject import *  # noqa: F401, F403
-from .reactionobject import *  # noqa: F401, F403
-from .roleobject import *  # noqa: F401, F403
-from .stageobject import *  # noqa: F401, F403
-from .templateobject import *  # noqa: F401, F403
-from .userobject import *  # noqa: F401, F403
-from .widgetobject import *  # noqa: F401, F403
+from .baseobject import *
+from .channelobject import *
+from .embedobject import *
+from .emojiobject import *
+from .guildobject import *
+from .integrationobject import *
+from .inviteobject import *
+from .memberobject import *
+from .messageobject import *
+from .reactionobject import *
+from .roleobject import *
+from .stageobject import *
+from .templateobject import *
+from .userobject import *
+from .widgetobject import *

--- a/snakecord/states/__init__.py
+++ b/snakecord/states/__init__.py
@@ -1,11 +1,11 @@
-from .basestate import *  # noqa: F401, F403
-from .channelstate import *  # noqa: F401, F403
-from .emojistate import *  # noqa: F401, F403
-from .guildstate import *  # noqa: F401, F403
-from .invitestate import *  # noqa: F401, F403
-from .memberstate import *  # noqa: F401, F403
-from .messagestate import *  # noqa: F401, F403
-from .reactionstate import *  # noqa: F401, F403
-from .rolestate import *  # noqa: F401, F403
-from .stagestage import *  # noqa: F401, F403
-from .userstate import *  # noqa: F401, F403
+from .basestate import *
+from .channelstate import *
+from .emojistate import *
+from .guildstate import *
+from .invitestate import *
+from .memberstate import *
+from .messagestate import *
+from .reactionstate import *
+from .rolestate import *
+from .stagestage import *
+from .userstate import *

--- a/snakecord/utils/__init__.py
+++ b/snakecord/utils/__init__.py
@@ -1,5 +1,5 @@
-from .events import *  # noqa: F401, F403
-from .json import *  # noqa: F401, F403
-from .misc import *  # noqa: F401, F403
-from .snowflake import *  # noqa: F401, F403
-from .undefined import *  # noqa: F401, F403
+from .events import *
+from .json import *
+from .misc import *
+from .snowflake import *
+from .undefined import *

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
 # F401 and F403 is when flake8 complains about imports
-# W503 is flake8 complaing about "a + \n b"
-# ignore = F401,F403,W503,E701
+per-file-ignores =
+    __init__.py: F401,F403


### PR DESCRIPTION
Instead of putting `# noqa: F401, F403` in every `__init__.py` file, we can just ignore these.