### PR TITLE
Make JsonObject more like dict

### DIFF
--- a/snekcord/json.py
+++ b/snekcord/json.py
@@ -101,6 +101,18 @@ class JsonObject(metaclass=JsonObjectMeta):
 
                 cls._json_fields_[name] = value
 
+    def __contains__(self, key):
+        return key in self._json_fields_
+
+    def __getitem__(self, key):
+        field = self._json_fields_[key]
+
+        value = field.get(self, undefined)
+        if value is undefined:
+            raise KeyError(key)
+
+        return value
+
     @classmethod
     def unmarshal(cls, data, **kwargs):
         if isinstance(data, (str, bytes)):
@@ -109,6 +121,11 @@ class JsonObject(metaclass=JsonObjectMeta):
         self = cls(**kwargs)
         self.update(data)
         return self
+
+    def get(self, key, default=None):
+        if key in self._json_fields_:
+            return self._json_fields_[key].get(self, default)
+        return default
 
     def update(self, data):
         self._json_data_.update(data)

--- a/snekcord/objects/emojiobject.py
+++ b/snekcord/objects/emojiobject.py
@@ -62,7 +62,7 @@ class CustomEmoji(BaseObject, _BaseCustomEmoji):
 
     @property
     def guild(self):
-        return self.state.client.guilds.get(CustomEmoji.guild_id.get(self))
+        return self.state.client.guilds.get(self.get('guild_id'))
 
     async def fetch_guild(self):
         if self.guild is not None:

--- a/snekcord/objects/messageobject.py
+++ b/snekcord/objects/messageobject.py
@@ -237,7 +237,7 @@ class Message(BaseObject):
 
     @property
     def webhook(self):
-        return self.state.client.webhooks.get(Message.webhook_id.get(self))
+        return self.state.client.webhooks.get(self.get('webhook_id'))
 
     @property
     def webhook_message(self):

--- a/snekcord/objects/stickerobject.py
+++ b/snekcord/objects/stickerobject.py
@@ -79,7 +79,7 @@ class GuildSticker(_BaseSticker):
 
     @property
     def guild(self):
-        return self.state.client.guilds.get(GuildSticker.guild_id.get(self))
+        return self.state.client.guilds.get(self.get('guild_id'))
 
     async def fetch_guild(self):
         if self.guild is not None:


### PR DESCRIPTION
This pr adds new methods to `JsonObject` to make it behave like a dictionary.
```py
'a' in obj
```
```py
x = obj.get('a', 10)
```
```py
obj['a']
```
These methods are basically equivalent to `getattr`/`hasattr` but without the overhead of raising an exception and calling the field's unmarshaller if it's not necessary.

Example:
```py
@client.on()
async def guild_message_create(evt):
    if 'content' in evt.message:
        # it's before April 2022
    else:
        # it's after April 2022